### PR TITLE
Make StarknetTokenBridge EIC2771 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Note: the frontend implementation of the bridges, can be found [here](https://gi
 
 This project contains scripts written in Python 3.9.
 
+## EIP2771 compliance
+
+We made the L1 bridge EIP2771 compliant by inheriting from [ERC2771Recipient.sol](https://github.com/opengsn/gsn/blob/master/packages/contracts/src/ERC2771Recipient.sol).
+
 
 ## Getting Started
 

--- a/src/solidity/ERC2771Recipient.sol
+++ b/src/solidity/ERC2771Recipient.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// solhint-disable no-inline-assembly
+pragma solidity >=0.6.9;
+
+import "./IERC2771Recipient.sol";
+
+/**
+ * @title The ERC-2771 Recipient Base Abstract Class - Implementation
+ *
+ * @notice Note that this contract was called `BaseRelayRecipient` in the previous revision of the GSN.
+ *
+ * @notice A base contract to be inherited by any contract that want to receive relayed transactions.
+ *
+ * @notice A subclass must use `_msgSender()` instead of `msg.sender`.
+ */
+abstract contract ERC2771Recipient is IERC2771Recipient {
+
+    /*
+     * Forwarder singleton we accept calls from
+     */
+    address private _trustedForwarder;
+
+    /**
+     * :warning: **Warning** :warning: The Forwarder can have a full control over your Recipient. Only trust verified Forwarder.
+     * @notice Method is not a required method to allow Recipients to trust multiple Forwarders. Not recommended yet.
+     * @return forwarder The address of the Forwarder contract that is being used.
+     */
+    function getTrustedForwarder() public virtual view returns (address forwarder){
+        return _trustedForwarder;
+    }
+
+    function _setTrustedForwarder(address _forwarder) internal {
+        _trustedForwarder = _forwarder;
+    }
+
+    /// @inheritdoc IERC2771Recipient
+    function isTrustedForwarder(address forwarder) public virtual override view returns(bool) {
+        return forwarder == _trustedForwarder;
+    }
+
+    /// @inheritdoc IERC2771Recipient
+    function _msgSender() internal override virtual view returns (address ret) {
+        if (msg.data.length >= 20 && isTrustedForwarder(msg.sender)) {
+            // At this point we know that the sender is a trusted forwarder,
+            // so we trust that the last bytes of msg.data are the verified sender address.
+            // extract sender address from the end of msg.data
+            assembly {
+                ret := shr(96,calldataload(sub(calldatasize(),20)))
+            }
+        } else {
+            ret = msg.sender;
+        }
+    }
+
+    /// @inheritdoc IERC2771Recipient
+    function _msgData() internal override virtual view returns (bytes calldata ret) {
+        if (msg.data.length >= 20 && isTrustedForwarder(msg.sender)) {
+            return msg.data[0:msg.data.length-20];
+        } else {
+            return msg.data;
+        }
+    }
+}

--- a/src/solidity/ERC2771Recipient.sol
+++ b/src/solidity/ERC2771Recipient.sol
@@ -2,6 +2,7 @@
 // solhint-disable no-inline-assembly
 pragma solidity >=0.6.9;
 
+import "starkware/solidity/libraries/NamedStorage.sol";
 import "./IERC2771Recipient.sol";
 
 /**
@@ -14,38 +15,37 @@ import "./IERC2771Recipient.sol";
  * @notice A subclass must use `_msgSender()` instead of `msg.sender`.
  */
 abstract contract ERC2771Recipient is IERC2771Recipient {
-
     /*
      * Forwarder singleton we accept calls from
      */
-    address private _trustedForwarder;
+    string internal constant TRUSTED_FORWARDER_TAG = "STARKNET_TOKEN_BRIDGE_TRUSTED_FORWARDER_TAG";
 
     /**
      * :warning: **Warning** :warning: The Forwarder can have a full control over your Recipient. Only trust verified Forwarder.
      * @notice Method is not a required method to allow Recipients to trust multiple Forwarders. Not recommended yet.
      * @return forwarder The address of the Forwarder contract that is being used.
      */
-    function getTrustedForwarder() public virtual view returns (address forwarder){
-        return _trustedForwarder;
+    function getTrustedForwarder() public view virtual returns (address forwarder) {
+        return NamedStorage.getAddressValue(TRUSTED_FORWARDER_TAG);
     }
 
     function _setTrustedForwarder(address _forwarder) internal {
-        _trustedForwarder = _forwarder;
+        NamedStorage.setAddressValueOnce(TRUSTED_FORWARDER_TAG, _forwarder);
     }
 
     /// @inheritdoc IERC2771Recipient
-    function isTrustedForwarder(address forwarder) public virtual override view returns(bool) {
-        return forwarder == _trustedForwarder;
+    function isTrustedForwarder(address forwarder) public view virtual override returns (bool) {
+        return forwarder == NamedStorage.getAddressValue(TRUSTED_FORWARDER_TAG);
     }
 
     /// @inheritdoc IERC2771Recipient
-    function _msgSender() internal override virtual view returns (address ret) {
+    function _msgSender() internal view virtual override returns (address ret) {
         if (msg.data.length >= 20 && isTrustedForwarder(msg.sender)) {
             // At this point we know that the sender is a trusted forwarder,
             // so we trust that the last bytes of msg.data are the verified sender address.
             // extract sender address from the end of msg.data
             assembly {
-                ret := shr(96,calldataload(sub(calldatasize(),20)))
+                ret := shr(96, calldataload(sub(calldatasize(), 20)))
             }
         } else {
             ret = msg.sender;
@@ -53,9 +53,9 @@ abstract contract ERC2771Recipient is IERC2771Recipient {
     }
 
     /// @inheritdoc IERC2771Recipient
-    function _msgData() internal override virtual view returns (bytes calldata ret) {
+    function _msgData() internal view virtual override returns (bytes calldata ret) {
         if (msg.data.length >= 20 && isTrustedForwarder(msg.sender)) {
-            return msg.data[0:msg.data.length-20];
+            return msg.data[0:msg.data.length - 20];
         } else {
             return msg.data;
         }

--- a/src/solidity/IERC2771Recipient.sol
+++ b/src/solidity/IERC2771Recipient.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+/**
+ * @title The ERC-2771 Recipient Base Abstract Class - Declarations
+ *
+ * @notice A contract must implement this interface in order to support relayed transaction.
+ *
+ * @notice It is recommended that your contract inherits from the ERC2771Recipient contract.
+ */
+abstract contract IERC2771Recipient {
+
+    /**
+     * :warning: **Warning** :warning: The Forwarder can have a full control over your Recipient. Only trust verified Forwarder.
+     * @param forwarder The address of the Forwarder contract that is being used.
+     * @return isTrustedForwarder `true` if the Forwarder is trusted to forward relayed transactions by this Recipient.
+     */
+    function isTrustedForwarder(address forwarder) public virtual view returns(bool);
+
+    /**
+     * @notice Use this method the contract anywhere instead of msg.sender to support relayed transactions.
+     * @return sender The real sender of this call.
+     * For a call that came through the Forwarder the real sender is extracted from the last 20 bytes of the `msg.data`.
+     * Otherwise simply returns `msg.sender`.
+     */
+    function _msgSender() internal virtual view returns (address);
+
+    /**
+     * @notice Use this method in the contract instead of `msg.data` when difference matters (hashing, signature, etc.)
+     * @return data The real `msg.data` of this call.
+     * For a call that came through the Forwarder, the real sender address was appended as the last 20 bytes
+     * of the `msg.data` - so this method will strip those 20 bytes off.
+     * Otherwise (if the call was made directly and not through the forwarder) simply returns `msg.data`.
+     */
+    function _msgData() internal virtual view returns (bytes calldata);
+}

--- a/src/solidity/IERC2771Recipient.sol
+++ b/src/solidity/IERC2771Recipient.sol
@@ -9,13 +9,12 @@ pragma solidity >=0.6.0;
  * @notice It is recommended that your contract inherits from the ERC2771Recipient contract.
  */
 abstract contract IERC2771Recipient {
-
     /**
      * :warning: **Warning** :warning: The Forwarder can have a full control over your Recipient. Only trust verified Forwarder.
      * @param forwarder The address of the Forwarder contract that is being used.
      * @return isTrustedForwarder `true` if the Forwarder is trusted to forward relayed transactions by this Recipient.
      */
-    function isTrustedForwarder(address forwarder) public virtual view returns(bool);
+    function isTrustedForwarder(address forwarder) public view virtual returns (bool);
 
     /**
      * @notice Use this method the contract anywhere instead of msg.sender to support relayed transactions.
@@ -23,7 +22,7 @@ abstract contract IERC2771Recipient {
      * For a call that came through the Forwarder the real sender is extracted from the last 20 bytes of the `msg.data`.
      * Otherwise simply returns `msg.sender`.
      */
-    function _msgSender() internal virtual view returns (address);
+    function _msgSender() internal view virtual returns (address);
 
     /**
      * @notice Use this method in the contract instead of `msg.data` when difference matters (hashing, signature, etc.)
@@ -32,5 +31,5 @@ abstract contract IERC2771Recipient {
      * of the `msg.data` - so this method will strip those 20 bytes off.
      * Otherwise (if the call was made directly and not through the forwarder) simply returns `msg.data`.
      */
-    function _msgData() internal virtual view returns (bytes calldata);
+    function _msgData() internal view virtual returns (bytes calldata);
 }

--- a/src/solidity/StarknetTokenBridge.sol
+++ b/src/solidity/StarknetTokenBridge.sol
@@ -604,14 +604,13 @@ contract StarknetTokenBridge is
         emit DepositReclaimed(_msgSender(), token, amount, l2Recipient, nonce);
     }
 
-
     // EIP2771 related functions
 
     function setTrustedForwarder(address _forwarder) public onlyManager {
         _setTrustedForwarder(_forwarder);
     }
 
-    function versionRecipient() external view override returns (string memory) {
+    function versionRecipient() external pure returns (string memory) {
         return "1";
     }
 }


### PR DESCRIPTION
This PR aims at making the contract StarknetTokenBridge EIP2771 compliant:
- by inheriting from the contract [ERC2771Recipient.sol](https://github.com/opengsn/gsn/blob/master/packages/contracts/src/ERC2771Recipient.sol) 
- by replacing `msg.sender` with `_msgSender()`
- by adding a function to set the trusted forwarder, and another to add recipient version.

We followed [this guide](https://docs-gasless.biconomy.io/products/enable-gasless-transactions/choose-an-approach-to-enable-gasless/eip-2771) from Biconomy to edit the contract.